### PR TITLE
Allowed make to work on stricter compilers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CC = gcc -std=c90
+CC = gcc -std=gnu99
 LEX = flex
 YACC = bison
 
@@ -11,4 +11,4 @@ yacc-config:
 	 $(YACC) -dyv parser/yacc.y
 
 build:
-	$(CC) lex.yy.c y.tab.c lists/ll.c lists/chain.c shell.c -g -o xshell
+	$(CC) lex.yy.c y.tab.c lists/ll.c lists/chain.c shell.c -g -Wno-int-conversion -Wno-implicit-function-declaration -Wno-conflicts-sr -o xshell


### PR DESCRIPTION
Down to the last error:
```
$ bison -dyv parser/yacc.y
parser/yacc.y: warning: 9 shift/reduce conflicts [-Wconflicts-sr]
```

Any ideas? - Clues: https://stackoverflow.com/q/1737460